### PR TITLE
changed padding calculation for proper bounding box position

### DIFF
--- a/preprocessing.py
+++ b/preprocessing.py
@@ -93,8 +93,9 @@ def _letterbox_image(
     left, right = int(dw_half), int(dw_half + 0.5)
 
     im = ImageOps.expand(im, border=(left, top, right, bottom), fill=color)
-
-    return im, r, (dw, dh)
+    
+    # return padding/2 to correct bounding box position
+    return im, r, (dw_half, dh_half)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
the padding value returned by the letterbox function should be divided by two for proper bounding box position on the original image.

This is how the same function is working in the starterapp-python code where the bounding box is properly placed on the image.

Reasonably well tested before merge, please have a good look during your own tests for possible side effects... :-)